### PR TITLE
fix: client secret string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-admin-client</artifactId>
-                <version>24.0.2</version>
+                <version>26.0.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/jp/openstandia/connector/keycloak/KeycloakUserHandler.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/KeycloakUserHandler.java
@@ -57,6 +57,9 @@ public class KeycloakUserHandler extends AbstractKeycloakHandler {
     // groups is a list of keycloak group's id
     public static final String ATTR_GROUPS = "groups";
 
+    // Association
+    public static final String ATTR_ROLES = "roles";
+
     // Password
     public static final String ATTR_PASSWORD = "__PASSWORD__";
     public static final String ATTR_PASSWORD_PERMANENT = "password_permanent";
@@ -72,6 +75,7 @@ public class KeycloakUserHandler extends AbstractKeycloakHandler {
         attrs.add(Name.NAME);
         attrs.add(ATTR_CREATED_TIMESTAMP);
         attrs.add(ATTR_GROUPS);
+        attrs.add(ATTR_ROLES);
         attrs.add(ATTR_PASSWORD_PERMANENT);
         attrs.addAll(OperationalAttributes.OPERATIONAL_ATTRIBUTE_NAMES);
 
@@ -183,6 +187,12 @@ public class KeycloakUserHandler extends AbstractKeycloakHandler {
 
         // Association
         builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_GROUPS)
+                .setMultiValued(true)
+                .setReturnedByDefault(false)
+                .build());
+
+        // Association
+        builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_ROLES)
                 .setMultiValued(true)
                 .setReturnedByDefault(false)
                 .build());

--- a/src/main/java/jp/openstandia/connector/keycloak/common/Transformation.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/common/Transformation.java
@@ -1,0 +1,41 @@
+package jp.openstandia.connector.keycloak.common;
+
+import org.identityconnectors.common.logging.Log;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Transformation {
+
+    private static final Log LOGGER = Log.getLog(Transformation.class);
+    public static Map<String, List<RoleRepresentation>> groupsToClientRoleMap(List<String> roleList,
+                                                                              String delimiter,
+                                                                              Integer clientIndex,
+                                                                              Integer groupIndex,
+                                                                              RealmResource realm){
+        Map<String, List<RoleRepresentation>> result = new HashMap<>();
+        roleList.stream().forEach(r -> {
+            String[] roleSplit = r.split(delimiter);
+            String clientId = roleSplit[clientIndex];
+            String roleName = roleSplit[groupIndex];
+            if(result.containsKey(clientId)){
+                result.get(clientId).add(getClientRoleRepresentation(realm, clientId, roleName));
+            }
+            else {
+                result.put(clientId, new ArrayList<RoleRepresentation>(){{add(getClientRoleRepresentation(realm, clientId, roleName));}});
+            }
+        });
+
+        return result;
+    }
+
+
+    private static RoleRepresentation getClientRoleRepresentation(RealmResource realm, String clientId, String roleName){
+        return realm.clients().get(clientId).roles().get(roleName).toRepresentation();
+    }
+
+}

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTClient.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTClient.java
@@ -427,7 +427,10 @@ public class KeycloakAdminRESTClient implements KeycloakClient.Client {
 
         // openid-connect
         if (shouldReturn(attributesToGet, ATTR_SECRET)) {
-            builder.addAttribute(ATTR_SECRET, rep.getSecret());
+            String secret = rep.getSecret();
+            if (secret != null) {
+                builder.addAttribute(AttributeBuilder.build(ATTR_SECRET, new GuardedString(secret.toCharArray())));
+            }
         }
         if (shouldReturn(attributesToGet, ATTR_PUBLIC_CLIENT)) {
             builder.addAttribute(ATTR_PUBLIC_CLIENT, rep.isPublicClient());


### PR DESCRIPTION
Fix: Client with secrets cannot be read from resource
Problem
When synchronizing Keycloak clients that have secrets configured, MidPoint throws a SchemaException during import/reconciliation:
```
SchemaException: The value 'PPV(String:xxx)' does not conform to the definition 
secret ({...types-3}ProtectedStringType): expected type: class ProtectedStringType, 
actual type: class java.lang.String
```
but MidPoint's schema defines it as ProtectedStringType, causing a type mismatch error.